### PR TITLE
fix: Ensure consistent line endings in Debian package

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -124,7 +124,7 @@ log_level=info
 log_file=/var/log/sample-app.log
 """
 
-    with open(os.path.join(config_dir, "test.conf"), "w") as f:
+    with open(os.path.join(config_dir, "test.conf"), "w", newline='\n') as f:
         f.write(test_conf_content)
 
     # Create DEBIAN control directory
@@ -146,7 +146,7 @@ log_file=/var/log/sample-app.log
         template = env.get_template(f"{template_name}.j2")
         content = template.render(template_context)
         filepath = os.path.join(control_dir, template_name)
-        with open(filepath, "w") as f:
+        with open(filepath, "w", newline='\n') as f:
             f.write(content)
         if template_name in ["preinst", "postinst", "postrm"]:
             set_permissions(filepath, 0o755)
@@ -166,8 +166,8 @@ log_file=/var/log/sample-app.log
 
     # Create debian-binary
     print("Creating debian-binary...")
-    with open("debian-binary", "w") as f:
-        f.write("2.0\n")
+    with open("debian-binary", "wb") as f:
+        f.write(b"2.0\n")
 
     # Assemble .deb package
     print("Assembling .deb package...")


### PR DESCRIPTION
The script was generating a Debian package with Windows-style line endings (`\r\n`) when run on a Windows machine. This caused the `ar` archive to have an invalid format, resulting in an error when trying to install the package on Ubuntu.

This commit fixes the issue by:
- Enforcing Unix-style line endings (`\n`) for all generated text files (`test.conf` and control files) by using the `newline='\n'` parameter in the `open()` function.
- Writing the `debian-binary` file in binary mode (`'wb'`) to prevent any line-ending translation.

These changes ensure that the generated Debian package is valid and can be installed correctly, regardless of the operating system it was built on.